### PR TITLE
treesitter: add rainbow brackets

### DIFF
--- a/config/treesitter.nix
+++ b/config/treesitter.nix
@@ -1,8 +1,11 @@
 {
-  plugins.treesitter = {
-    enable = true;
-    nixGrammars = true;
-    indent = true;
+  plugins = {
+    treesitter = {
+      enable = true;
+      nixGrammars = true;
+      indent = true;
+    };
+    treesitter-context.enable = true;
+    rainbow-delimiters.enable = true;
   };
-  plugins.treesitter-context.enable = true;
 }


### PR DESCRIPTION
This adds rainbow delimiters to the nix config.

How it looks:
![Screenshot_20231019_223453](https://github.com/MikaelFangel/nixvim-config/assets/34864484/4b8f519a-cbfd-4016-846f-590240878927)
