### PR TITLE
ruff-lsp: init

### DIFF
--- a/config/lsp.nix
+++ b/config/lsp.nix
@@ -4,9 +4,10 @@
     servers = {
       bashls.enable = true;
       clangd.enable = true;
+      fsautocomplete.enable = true;
       gopls.enable = true;
       nixd.enable = true;
-      fsautocomplete.enable = true;
+      ruff-lsp.enable = true;
     };
     keymaps.lspBuf = {
       "gd" = "definition";


### PR DESCRIPTION
### Changes
Adds the ruff-lsp to the configuration. This lsp should replace a lot of plugins for Python projects and be fast as well, hence the choice.
