### PR TITLE
markdownlint: init

### DIFF
--- a/config/none-ls.nix
+++ b/config/none-ls.nix
@@ -9,6 +9,7 @@
       formatting = {
         fantomas.enable = true;
         nixfmt.enable = true;
+        markdownlint.enable = true;
       };
     };
   };


### PR DESCRIPTION
This PR only adds the formatting support for markdown because I feel the markdown preview option is too extensive. Also, highlighting is solved by the already enabled treesitter plugin.

Lastly, I couldn't find any suitable options for linting and maybe markdown is too simple to need it anyway.

### Changes
 - Adds formatting support for markdown files through none-ls