### PR TITLE
nix-develop: init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,5 +40,7 @@
         # Lets you run `nix run .` to start nixvim
         default = nvim;
       };
+
+      devShells.default = import ./shell.nix { inherit pkgs; };
     });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    # Rust
+    cargo
+    rustc
+
+    # FSharp
+    dotnet-sdk
+  ];
+}


### PR DESCRIPTION
Adds the option to write `nix develop` when testing the configuration.
