### PR TITLE
toggleterm: remove forced shell value for zsh

### DIFF
--- a/config/toggleterm.nix
+++ b/config/toggleterm.nix
@@ -3,6 +3,5 @@
     enable = true;
     openMapping = "<C-t>";
     direction = "horizontal";
-    shell = "zsh";
   };
 }


### PR DESCRIPTION
By removing the line `shell = "zsh"` toggleterm should default to the systems user shell. My preliminary shows that it works as expected with zsh on my system.

@PhilipCramer - please verify this actually fixes #33
