### PR TITLE
rs-analyzer: add shortcut

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -43,6 +43,14 @@
       action = "<C-\\><C-n>";
     }
 
+    # Rust
+    {
+      # Start standalone rust-analyzer (fixes issues when opening files from nvim tree)
+      mode = "n";
+      key = "<leader>rs";
+      action = "<CMD>RustStartStandaloneServerForBuffer<CR>";
+    }
+
     # {
     #   # Mode can be a string or a list of strings
     #   mode = "n";


### PR DESCRIPTION
Adds a shortcut for starting the rs-analyzer in case it fails to start automatically.
