### PR TITLE
theme: disable for macos

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -19,7 +19,7 @@
     ./toggleterm.nix
   ];
 
-  colorschemes.dracula.enable = true;
+  colorschemes.dracula.enable = pkgs.stdenv.isLinux;
 
   keymaps = [
     # Global Mappings

--- a/config/default.nix
+++ b/config/default.nix
@@ -19,6 +19,7 @@
     ./toggleterm.nix
   ];
 
+  # The theme doesn't work properly on MacOS using the default terminal
   colorschemes.dracula.enable = pkgs.stdenv.isLinux;
 
   keymaps = [


### PR DESCRIPTION
### Changes
 - Enable the theme only if on Linux due to an issue with the theme not displaying properly on MacOS with the default terminal emulator.

### Image of how it was before on MacOS
![Screenshot 2024-04-16 at 10 43 35](https://github.com/MikaelFangel/nixvim-config/assets/34864484/7be4ea3e-7801-4412-8e82-76f8df71d562)

### Image of the result of the change on MacOS
![Screenshot 2024-04-16 at 10 45 26](https://github.com/MikaelFangel/nixvim-config/assets/34864484/c52eb115-932e-4962-aca4-c12d089c6368)
