### PR TITLE
formatter: use system variable instead

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         };
       in
       {
-        formatter = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
+        formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
 
         checks = {
           default = nixvimLib.check.mkTestDerivationFromNvim {


### PR DESCRIPTION
### Changes:
 - Made the formatter use the system variable instead so it can be used by other systems than x86 Linux.