### PR TITLE
trouble: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Descriptions of all the config files/plugins used in this configuration.
 | telescope.nix | Extendable fuzzy finder over lists. |
 | toggleterm.nix | Management of multiple terminal windows. |
 | treesitter.nix | Syntax highlighting and indentation based on Tree-sitter. |
+| trouble.nix | Provides a pretty list for showing diagnostics, references, telescope results, quickfix and location lists | 
 | which_key.nix | Popup display of keybindings. |
 
 ## Contributing

--- a/config/default.nix
+++ b/config/default.nix
@@ -16,6 +16,7 @@
     ./telescope.nix
     ./toggleterm.nix
     ./treesitter.nix
+    ./trouble.nix
     ./which_key.nix
     ./wilder.nix
   ];
@@ -112,6 +113,18 @@
       key = "<esc>";
       action = "<C-\\><C-n>";
       options.desc = "Escape terminal mode";
+    }
+
+    # Trouble 
+    {
+      mode = "n";
+      key = "<leader>d";
+      action = "+diagnostics/debug";
+    }
+    {
+      key = "<leader>dt";
+      action = "<CMD>TroubleToggle<CR>";
+      options.desc = "Toggle trouble";
     }
 
     # Rust

--- a/config/git.nix
+++ b/config/git.nix
@@ -1,6 +1,9 @@
 {
   plugins.gitsigns = {
     enable = true;
-    settings.current_line_blame = true;
+    settings = {
+      current_line_blame = true;
+      trouble = true;
+    };
   };
 }

--- a/config/lsp.nix
+++ b/config/lsp.nix
@@ -1,23 +1,29 @@
 {
-  plugins.lsp = {
-    enable = true;
-    servers = {
-      bashls.enable = true;
-      clangd.enable = true;
-      elixirls.enable = true;
-      fsautocomplete.enable = true;
-      gopls.enable = true;
-      kotlin-language-server.enable = true;
-      nixd.enable = true;
-      ruff-lsp.enable = true;
+  plugins = {
+    lsp = {
+      enable = true;
+      servers = {
+        bashls.enable = true;
+        clangd.enable = true;
+        elixirls.enable = true;
+        fsautocomplete.enable = true;
+        gopls.enable = true;
+        kotlin-language-server.enable = true;
+        nixd.enable = true;
+        ruff-lsp.enable = true;
+      };
+      keymaps.lspBuf = {
+        "gd" = "definition";
+        "gD" = "references";
+        "gt" = "type_definition";
+        "gi" = "implementation";
+        "K" = "hover";
+      };
     };
-    keymaps.lspBuf = {
-      "gd" = "definition";
-      "gD" = "references";
-      "gt" = "type_definition";
-      "gi" = "implementation";
-      "K" = "hover";
+    lsp-lines = {
+      enable = true;
+      currentLine = true;
     };
+    rust-tools.enable = true;
   };
-  plugins.rust-tools.enable = true;
 }

--- a/config/trouble.nix
+++ b/config/trouble.nix
@@ -1,0 +1,5 @@
+{
+  plugins = {
+    trouble.enable = true;
+  };
+}


### PR DESCRIPTION
### Changes: 
 - Enable trouble
 - Add shortcuts for trouble
 - Update the readme
 - Enabled lsp-lines for prettier virtual-texts


## Screenshots
### LSP Line
Shows the error inline for the current line and adds an `E` to the gutter on other errors.
![Screenshot 2024-05-06 at 10 29 40](https://github.com/MikaelFangel/nixvim-config/assets/34864484/d44037fc-658d-4290-942e-7f28f60856ee)
![Screenshot 2024-05-06 at 10 29 55](https://github.com/MikaelFangel/nixvim-config/assets/34864484/f403ced6-ee21-43fd-9983-61ce4b9e6767)

### Trouble (Shows all errors)
![Screenshot 2024-05-06 at 10 31 45](https://github.com/MikaelFangel/nixvim-config/assets/34864484/64a28820-1b38-48fc-bff5-c9e660fec83c)


CC @PhilipCramer for testing and opinions.