### PR TITLE
theme: enable dracula theme for macos

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -21,8 +21,7 @@
     ./wilder.nix
   ];
 
-  # The theme doesn't work properly on MacOS using the default terminal
-  colorschemes.dracula.enable = pkgs.stdenv.isLinux;
+  colorschemes.dracula.enable = true;
 
   globals.mapleader = " ";
 

--- a/config/default.nix
+++ b/config/default.nix
@@ -1,5 +1,3 @@
-{ pkgs, ... }:
-
 {
   imports = [
     ./auto-pairs.nix

--- a/config/options.nix
+++ b/config/options.nix
@@ -1,3 +1,5 @@
+{lib, pkgs, ...}:
+
 {
   config.opts = {
     updatetime = 100; # Faster completion
@@ -19,5 +21,7 @@
 
     swapfile = false;
     undofile = true; # Build-in persistent undo
+
+    termguicolors = lib.mkForce pkgs.stdenv.isLinux;
   };
 }

--- a/config/options.nix
+++ b/config/options.nix
@@ -1,4 +1,4 @@
-{lib, pkgs, ...}:
+{ lib, pkgs, ... }:
 
 {
   config.opts = {


### PR DESCRIPTION
### Changes
 - Disable termguicolors on MacOS so that the theme again works with the default terminal.