### PR TITLE
lsp: remove fsautocomplete

### DIFF
--- a/config/lsp.nix
+++ b/config/lsp.nix
@@ -6,7 +6,6 @@
         bashls.enable = true;
         clangd.enable = true;
         elixirls.enable = true;
-        fsautocomplete.enable = true;
         gopls.enable = true;
         kotlin-language-server.enable = true;
         nixd.enable = true;

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,8 @@ pkgs.mkShell {
 
     # FSharp
     dotnet-sdk
+    fsautocomplete
+    fantomas
 
     # Go
     go


### PR DESCRIPTION
Fixes: #25, #29

### Changes
 - Remove fsautocomplete from the lsp. 
 - Users are now required to install fsautocomplete before ionide works.
 - Add fsautocomplete to the shell.