### PR TITLE
treesitter-context: set a max limit for contexts

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -33,6 +33,15 @@
       action = "<CMD>NvimTreeToggle<CR>";
       options.desc = "Toggle NvimTree";
     }
+    {
+      key = "<leader>c";
+      action = "+context";
+    }
+    {
+      key = "<leader>co";
+      action = "<CMD>TSContextToggle<CR>";
+      options.desc = "Toggle Treesitter context";
+    }
 
     # File
     {

--- a/config/treesitter.nix
+++ b/config/treesitter.nix
@@ -5,7 +5,10 @@
       nixGrammars = true;
       indent = true;
     };
-    treesitter-context.enable = true;
+    treesitter-context = {
+      enable = true;
+      settings = { max_lines = 2; };
+    };
     rainbow-delimiters.enable = true;
   };
 }


### PR DESCRIPTION
Fixes: #16 

### Changes 
 - Set max lines for treesitter-context
 - Add keymaps for toggling treesitter-context

See the wiki for all keymaps: https://github.com/MikaelFangel/nixvim-config/wiki/Key-Mappings