### PR TITLE
cmp: update keymaps

### DIFF
--- a/config/cmp.nix
+++ b/config/cmp.nix
@@ -34,6 +34,7 @@
       enable = true;
 
       settings = {
+        experimental = { ghost_text = true; };
         snippet.expand = ''
           function(args)
             require('luasnip').lsp_expand(args.body)
@@ -131,10 +132,20 @@
           "<C-d>" = "cmp.mapping.scroll_docs(-4)";
           "<C-f>" = "cmp.mapping.scroll_docs(4)";
           "<C-Space>" = "cmp.mapping.complete()";
-          "<C-e>" = "cmp.mapping.close()";
-          "<CR>" =
-            "cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = true })";
+          "<S-Tab>" = "cmp.mapping.close()";
           "<Tab>" =
+            # lua 
+            ''
+              function(fallback)
+                local line = vim.api.nvim_get_current_line()
+                if line:match("^%s*$") then
+                  fallback()
+                else
+                  cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = true })
+                end
+              end
+            '';
+          "<Up>" =
             # lua
             ''
               function(fallback)
@@ -147,7 +158,7 @@
                 end
               end
             '';
-          "<S-Tab>" =
+          "<Down>" =
             # lua
             ''
               function(fallback)

--- a/config/cmp.nix
+++ b/config/cmp.nix
@@ -140,8 +140,10 @@
                 local line = vim.api.nvim_get_current_line()
                 if line:match("^%s*$") then
                   fallback()
+                elseif cmp.visible() then
+                  cmp.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = true })
                 else
-                  cmp.mapping.confirm({ behavior = cmp.ConfirmBehavior.Insert, select = true })
+                  fallback()
                 end
               end
             '';


### PR DESCRIPTION
Unfortunately the current keymaps interfere with your writing flow because copilot eagerly tries to complete a line even if it only contains whitespace. This makes it hard to write languages that are whitespace-sensitive e.g. Python and F#.

### Changes
 - This updates the keycap for completion and makes it so autocompletion won't trigger on lines with only whitespace
 - Shadows completion text

| Keymap | Functionality |
| -------|---------------|
| Tab | Autocomplete if at least one non-whitespace is present |
| S-Tab | Close completion menu | 
| Up | Select prev completion |
| Down | Select next completion |

CC @PhilipCramer @Greve2001 - For opinions and testing.