### PR TITLE
treesitter: enable highlighting

### DIFF
--- a/config/treesitter.nix
+++ b/config/treesitter.nix
@@ -3,7 +3,10 @@
     treesitter = {
       enable = true;
       nixGrammars = true;
-      settings.indent.enable = true;
+      settings = {
+        highlight.enable = true;
+        indent.enable = true;
+      };
     };
     treesitter-context = {
       enable = true;


### PR DESCRIPTION
### Changes
 - Enable Treesitter highlighting to fix missing highlighting in Elixir.