### PR TITLE
fix!: disable gcc for treesitter

### DIFF
--- a/config/treesitter.nix
+++ b/config/treesitter.nix
@@ -2,6 +2,7 @@
   plugins = {
     treesitter = {
       enable = true;
+      gccPackage = null;
       nixGrammars = true;
       settings = {
         highlight.enable = true;


### PR DESCRIPTION
The treesitter GCC package causes problems on Apple silicon with Elixir and bcrypt.