### PR TITLE
fix!: set lsp language packages to null to use system wide packages

### DIFF
--- a/config/lsp/default.nix
+++ b/config/lsp/default.nix
@@ -5,18 +5,35 @@
     lsp = {
       enable = true;
       servers = {
+        # Common language servers
         bashls.enable = true;
         clangd.enable = true;
-        elixirls.enable = true;
-        gleam.enable = true;
-        gopls.enable = true;
-        kotlin_language_server.enable = true;
         nixd.enable = true;
+        ruff.enable = true;
+
+        # Packages is set to null to rely on the system wide installed packages
+        # this is done to avoid conflicts with the nixpkgs versions.
+        elixirls = {
+          enable = true;
+          package = null; # default pkgs.elixir-ls
+          cmd = [ "elixir-ls" ];
+        };
+        gleam = {
+          enable = true;
+          package = null; # default pkgs.gleam
+        };
+        gopls = {
+          enable = true;
+          package = null; # default pkgs.gopls
+        };
+        kotlin_language_server = {
+          enable = true;
+          package = null; # default pkgs.kotlin-language-server
+        };
         prolog_ls = {
           enable = true;
-          package = pkgs.swi-prolog;
+          package = null; # default pkgs.swi-prolog;
         };
-        ruff.enable = true;
       };
       keymaps.lspBuf = {
         "gd" = "definition";


### PR DESCRIPTION
### Motivation

When developing Elixir and you have elixir-ls enable it can use one version of Elixir and your system another. This can result in conflicts between the two compilers which force full recompilations of your elixir project and other weird compiler errors.

### Changes

 - Set less common languages LSP packages to null, to rely on system installations.
 - Set elixir-ls command back from null.

### References

 - https://nix-community.github.io/nixvim/user-guide/faq.html?highlight=package%20null#how-to-use-system-provided-binaries-instead-of-nixvim-provided-ones

CC @PhilipCramer and @Greve2001 for testing.